### PR TITLE
Fix PTT

### DIFF
--- a/src/config/rigconfig.cpp
+++ b/src/config/rigconfig.cpp
@@ -129,6 +129,7 @@ void rigConfig::getParams()
   getValue(cp->activeDTR,ui->DTRCheckBox);
   getValue(cp->nactiveRTS,ui->nRTSCheckBox);
   getValue(cp->nactiveDTR,ui->nDTRCheckBox);
+  if(ui->noPttRadioButton->isChecked()) cp->pttType=RIG_PTT_NONE;
   if(ui->catVoiceRadioButton->isChecked()) cp->pttType=RIG_PTT_RIG;
   if(ui->catDataRadioButton->isChecked()) cp->pttType=RIG_PTT_RIG_MICDATA;
   if(ui->rtsRadioButton->isChecked()) cp->pttType=RIG_PTT_SERIAL_RTS;
@@ -195,7 +196,7 @@ void rigConfig::setParams()
       setValue(true,ui->dtrRadioButton);
     break;
     default:
-      setValue(true,ui->catVoiceRadioButton);
+      setValue(true,ui->noPttRadioButton);
     break;
     }
   if(cp->enableCAT && cp->enableSerialPTT)

--- a/src/config/rigconfig.ui
+++ b/src/config/rigconfig.ui
@@ -582,9 +582,6 @@
           <property name="text">
            <string>CAT (Voice port)</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
         <item>
@@ -614,6 +611,16 @@
          <widget class="QRadioButton" name="dtrRadioButton">
           <property name="text">
            <string>DTR</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="noPttRadioButton">
+          <property name="text">
+           <string>None</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/src/rig/rigcontrol.cpp
+++ b/src/rig/rigcontrol.cpp
@@ -129,7 +129,9 @@ bool rigControl::init()
   canGetFreq=(my_rig->caps->get_freq != NULL);
   canSetMode=(my_rig->caps->set_mode != NULL);
   canGetMode=(my_rig->caps->get_mode != NULL);
-  canSetPTT=(my_rig->caps->set_ptt != NULL);
+  canSetPTT=(my_rig->caps->set_ptt != NULL) ||
+          (my_rig->state.pttport.type.ptt == RIG_PTT_SERIAL_DTR) ||
+          (my_rig->state.pttport.type.ptt == RIG_PTT_SERIAL_RTS);
   canGetPTT=(my_rig->caps->get_ptt != NULL);
   double fr;
   getFrequency(fr);


### PR DESCRIPTION
If there was a PTT configured on the CAT interface as RTS or DTR, it did not work at all.

The reason is that in `rigControl::init()` the attribute `canSetPTT` was derived solely based on the rig's CAT capability to activate the PTT through the CAT protocol. If the rig did not support it that way (thus the capability is missing), no attempt was later made to actually use DTR or RTS to activate it – even though hamlib would have supported it.

The fix is to set the internal attribute also if RTS or DTR PTT has been configured, basically since the operator than claims that there is a PTT attached that way.

Also, it's a bit confusing when setting up the CAT interface, there is no option to have no PTT on that interface at all – e.g. since the PTT is to be configured through another serial interface, or if there is just VOX-only operation desired. It did eventually work anyway (since the default is to use CAT, but when CAT doesn't support PTT, it just did nothing), but it seems that a radio button to explicitly disable PTT on CAT makes the configuration more obvious.

This PR fixes issue #5 