### PR TITLE
Template is re-applied before sending

### DIFF
--- a/src/mainwidgets/txwidget.cpp
+++ b/src/mainwidgets/txwidget.cpp
@@ -318,6 +318,7 @@ void txWidget::prepareTx()
 {
   addToLog(QString("doTx=%1").arg(doTx),LOGTXMAIN);
   enableButtons(false);
+  applyTemplate();
   switch (transmissionModeIndex)
     {
     case TRXSSTV: txFunctionsPtr->prepareTX(txFunctions::TXPREPARESSTV);


### PR DESCRIPTION
Template is re-applied before sending to regenerate %t macro and ensure any changes since loading the image are represented.