### PR TITLE
Add option to recursively scan directories

### DIFF
--- a/src/config/directoriesconfig.cpp
+++ b/src/config/directoriesconfig.cpp
@@ -32,6 +32,7 @@ QString templatesPath;
 QString audioPath;
 bool saveTXimages;
 QString docURL;
+bool recursiveScanDirs;
 
 
 
@@ -66,6 +67,7 @@ void directoriesConfig::readSettings()
   audioPath=qSettings.value("audioPath",QString(getenv("HOME"))+"/qsstv/audio/").toString();
   docURL=qSettings.value("docURL","http://users.telenet.be/on4qz/qsstv/manual").toString();
   saveTXimages=qSettings.value("saveTXimages",false).toBool();
+  recursiveScanDirs=qSettings.value("recursiveScanDirs",false).toBool();
   qSettings.endGroup();
   setParams();
 }
@@ -84,7 +86,7 @@ void directoriesConfig::writeSettings()
   qSettings.setValue("audioPath",audioPath);
   qSettings.setValue("docURL",docURL);
   qSettings.setValue("saveTXimages",saveTXimages);
-
+  qSettings.setValue("recursiveScanDirs",recursiveScanDirs);
   qSettings.endGroup();
 }
 
@@ -105,6 +107,7 @@ void directoriesConfig::getParams()
   getValue(audioPath,ui->audioPathLineEdit);
   getValue(docURL,ui->docPathLineEdit);
   getValue(saveTXimages,ui->saveTXcheckBox);
+  getValue(recursiveScanDirs,ui->recursiveScanDirscheckBox);
   changed=false;
   if(rxSSTVImagePathSaved!=rxSSTVImagesPath || rxDRMImagePathSaved!=rxDRMImagesPath ||
      txSSTVImagePathSaved!=txSSTVImagesPath ||
@@ -126,6 +129,7 @@ void directoriesConfig::setParams()
   setValue(audioPath,ui->audioPathLineEdit);
   setValue(docURL,ui->docPathLineEdit);
   setValue(saveTXimages,ui->saveTXcheckBox);
+  setValue(recursiveScanDirs,ui->recursiveScanDirscheckBox);
   // create directories if not exist
   createDir(rxSSTVImagesPath);
   createDir(rxDRMImagesPath);

--- a/src/config/directoriesconfig.h
+++ b/src/config/directoriesconfig.h
@@ -12,6 +12,7 @@ extern QString templatesPath;
 extern QString audioPath;
 extern bool saveTXimages;
 extern QString docURL;
+extern bool recursiveScanDirs;
 
 namespace Ui {
 class directoriesConfig;

--- a/src/config/directoriesconfig.ui
+++ b/src/config/directoriesconfig.ui
@@ -436,6 +436,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="recursiveScanDirscheckBox">
+     <property name="text">
+      <string>Recursively scan directories for files</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="spacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/mainwidgets/gallerywidget.cpp
+++ b/src/mainwidgets/gallerywidget.cpp
@@ -3,6 +3,7 @@
 #include "configparams.h"
 #include "logging.h"
 #include "appglobal.h"
+#include "filewatcher.h"
 #include <QSplashScreen>
 #include "dispatch/dispatcher.h"
 #include <QFileInfo>
@@ -29,8 +30,6 @@ galleryWidget::~galleryWidget()
 }
 
 
-
-
 void galleryWidget::init()
 {
   readSettings();
@@ -49,11 +48,14 @@ void galleryWidget::changedMatrix()
 
 void galleryWidget::slotDirChanged(QString dn)
 {
-  if(dn==txStockImagesPath)
+  if(recursiveScanDirs) {
+    fileWatcherPtr->addPathRecursive(dn);
+  }
+  if(dn.startsWith(txStockImagesPath))
     {
       ui->txStockMatrix->changed();
     }
-  if(dn==templatesPath)
+  if(dn.startsWith(templatesPath))
     {
       ui->templateMatrix->changed();
       txWidgetPtr->setupTemplatesComboBox();

--- a/src/utils/filewatcher.cpp
+++ b/src/utils/filewatcher.cpp
@@ -13,7 +13,25 @@ void fileWatcher::init()
     {
       removePaths(directories());
     }
-  addPath(txStockImagesPath);
-  addPath(templatesPath);
+
+  addPathRecursive(txStockImagesPath);
+  addPathRecursive(templatesPath);
+
   connect(this,SIGNAL(directoryChanged(QString)),galleryWidgetPtr,SLOT(slotDirChanged(QString)));
+}
+
+void fileWatcher::addPathRecursive(QString path)
+{
+  addPath(path);
+  if(recursiveScanDirs) {
+    QDirIterator it(path, QDir::Dirs | QDir::NoSymLinks | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+
+    while (it.hasNext()) {
+      it.next();
+      QString f(it.filePath());
+      if(!f.endsWith("cache")) {
+        addPath(f);
+      }
+    }
+  }
 }

--- a/src/utils/filewatcher.h
+++ b/src/utils/filewatcher.h
@@ -10,9 +10,8 @@ public:
   fileWatcher();
   void init();
 
-signals:
-
 public slots:
+  void addPathRecursive(QString path);
 };
 
 #endif // FILEWATCHER_H

--- a/src/widgets/imagematrix.cpp
+++ b/src/widgets/imagematrix.cpp
@@ -141,11 +141,11 @@ void imageMatrix::getList()
 
 
     while (it.hasNext()) {
-        it.next();
-        QFileInfo f(it.fileInfo());
-        if(!f.canonicalPath().endsWith("cache")) {
-         fileList.append(f);
-        }
+      it.next();
+      QFileInfo f(it.fileInfo());
+      if(!f.canonicalPath().endsWith("cache")) {
+        fileList.append(f);
+      }
     }
     std::sort(fileList.begin(), fileList.end(), compareFile);
     numPages=ceil((double)fileList.count()/(double)(rows*columns));
@@ -165,7 +165,6 @@ QString imageMatrix::getLastFile()
 void imageMatrix::displayFiles()
 {
   int i,j,k;
-
   QString tempStr;
   int offset=currentPage*rows*columns;
   pageLabel->setText(QString("   Page %1 of %2").arg(currentPage+1).arg(numPages).leftJustified(17,' '));

--- a/src/widgets/imageviewer.cpp
+++ b/src/widgets/imageviewer.cpp
@@ -148,10 +148,16 @@ bool imageViewer::openImage(QString &filename,QString start,bool ask,bool showMe
 
   if(fromCache)
     {
+      cachePath=finf.absolutePath()+"/cache/";
+      QDir dd(cachePath);
+      if(!dd.exists())
+        {
+          dd.mkpath(cachePath);
+        }
 #if (QT_VERSION < QT_VERSION_CHECK(5,10,0))
-      cacheFileName=finf.absolutePath()+"/cache/"+finf.baseName()+finf.created().toString()+".png";
+      cacheFileName=cachePath+finf.baseName()+finf.created().toString()+".png";
 #else
-      cacheFileName=finf.absolutePath()+"/cache/"+finf.baseName()+finf.birthTime().toString()+".png";
+      cacheFileName=cachePath+finf.baseName()+finf.birthTime().toString()+".png";
 #endif
       if(tempImage.load(cacheFileName))
         {

--- a/src/widgets/imageviewer.h
+++ b/src/widgets/imageviewer.h
@@ -184,6 +184,7 @@ private:
   QImage tempImage;
   bool emitSignal;
   QString cacheFileName;
+  QString cachePath;
   bool  processImageDisplay(bool success, bool showMessage, bool fromCache);
 #ifdef IMAGETESTVIEWER
   void imageTestViewer(QImage *im, QString infoStr);


### PR DESCRIPTION
An option in the directories sub screen that allows recursive scanning of all the directories.

My tx_stock is growing by the week and this allows me to section it out by the folders i load in.