### PR TITLE
Disable SSTV/DRM tab during TX

### DIFF
--- a/src/mainwidgets/txwidget.cpp
+++ b/src/mainwidgets/txwidget.cpp
@@ -491,6 +491,7 @@ void txWidget::enableButtons(bool enable)
   ui->templateCheckBox->setEnabled(enable);
   ui->templatesComboBox->setEnabled(enable);
   ui->refreshPushButton->setEnabled(enable);
+  ui->settingsTableWidget->setEnabled(enable);
 }
 
 


### PR DESCRIPTION
This disables the SSTV/DRM tab during TX.

Switching a tab while transmitting re-initializes the whole thing and kills of your current TX. I've done it more than enough times just mindlessly clicking on it mid-transmission.

![diasble-tabs-on-tx](https://user-images.githubusercontent.com/382760/200555895-d3c7f125-071c-4da3-a5cd-b6a58c17235e.gif)
