### PR TITLE
Enable/Disable of the 'To Tx' action across the gallery

### DIFF
--- a/src/mainwidgets/gallerywidget.cpp
+++ b/src/mainwidgets/gallerywidget.cpp
@@ -62,6 +62,15 @@ void galleryWidget::slotDirChanged(QString dn)
     }
 }
 
+void galleryWidget::setTXEnabled(bool enabled) {
+    ui->rxSSTVMatrix->setTXEnabled(enabled);
+    ui->rxDRMMatrix->setTXEnabled(enabled);
+    ui->txSSTVMatrix->setTXEnabled(enabled);
+    ui->txDRMMatrix->setTXEnabled(enabled);
+    ui->txStockMatrix->setTXEnabled(enabled);
+    ui->templateMatrix->setTXEnabled(enabled);
+}
+
 
 void galleryWidget::changedMatrix(imageViewer::thumbType itype)
 {

--- a/src/mainwidgets/gallerywidget.h
+++ b/src/mainwidgets/gallerywidget.h
@@ -27,9 +27,11 @@ public:
   void putRxImage(QString fn);
   void txImageChanged ();
   void txStockImageChanged();
+  void setTXEnabled(bool enabled);
   QString getTemplateFileName(int);
   const QStringList &getFilenames();
   QString getLastRxImage();
+
 
 public slots:
   void slotDirChanged(QString);

--- a/src/mainwidgets/txwidget.cpp
+++ b/src/mainwidgets/txwidget.cpp
@@ -491,6 +491,7 @@ void txWidget::enableButtons(bool enable)
   ui->templateCheckBox->setEnabled(enable);
   ui->templatesComboBox->setEnabled(enable);
   ui->refreshPushButton->setEnabled(enable);
+  galleryWidgetPtr->setTXEnabled(enable);
 }
 
 

--- a/src/widgets/imagematrix.cpp
+++ b/src/widgets/imagematrix.cpp
@@ -1,4 +1,4 @@
-#include "imagematrix.h"
+﻿#include "imagematrix.h"
 #include "configparams.h"
 #include <QDir>
 #include <QDebug>
@@ -241,4 +241,16 @@ void imageMatrix::slotLayoutChanged()
     }
   currentPage=curPag;
   displayFiles();
+}
+
+void imageMatrix::setTXEnabled(bool enabled) {
+    int i,j;
+
+    for(i=0;i<rows;i++)
+    {
+        for(j=0;j<columns;j++)
+        {
+            ((imageViewer *)gridLayout->itemAtPosition(i,j)->widget())->setTXEnabled(enabled);
+        }
+    }
 }

--- a/src/widgets/imagematrix.h
+++ b/src/widgets/imagematrix.h
@@ -22,6 +22,7 @@ public:
   QFileInfoList getFileList(){return fileList;}
   QString getLastFile();
   void setSortFlag(QDir::SortFlags sf) {sortFlags=sf;}
+  void setTXEnabled(bool enabled);
 
 private:
   void getList();

--- a/src/widgets/imageviewer.cpp
+++ b/src/widgets/imageviewer.cpp
@@ -116,6 +116,10 @@ void imageViewer::init(thumbType tp)
   clear();
 }
 
+void imageViewer::setTXEnabled(bool enabled) {
+  toTXAct->setEnabled(enabled);
+}
+
 bool imageViewer::openImage(QString &filename,QString start,bool ask,bool showMessage,bool temitSignal,bool fromCache,bool background)
 {
   //background=false;

--- a/src/widgets/imageviewer.h
+++ b/src/widgets/imageviewer.h
@@ -103,7 +103,7 @@ public:
 
 
   int applyTemplate();
-
+  void setTXEnabled(bool enabled);
 
 protected:
   void resizeEvent(QResizeEvent *);
@@ -126,7 +126,6 @@ private slots:
   void slotZoomOut();
   void slotLeftClick();
   void slotJp2ImageDone(bool success, bool fromCache);
-
 
 signals:
   void layoutChanged();
@@ -186,6 +185,7 @@ private:
   QString cacheFileName;
   QString cachePath;
   bool  processImageDisplay(bool success, bool showMessage, bool fromCache);
+  void setCanTX(bool canTx);
 #ifdef IMAGETESTVIEWER
   void imageTestViewer(QImage *im, QString infoStr);
 #endif


### PR DESCRIPTION
This disables the "To TX" action in the gallery when transmitting.

If you send a new image to tx mid-way through transmit, it starts transmitting the new image after a few lines. This stops you accidentally doing that.

![disable-to-tx](https://user-images.githubusercontent.com/382760/200584944-a638db6c-8cf8-468e-b363-46831a726a39.gif)
