### PR TITLE
More Qt6 fixes

### DIFF
--- a/src/videocapt/cameradialog.cpp
+++ b/src/videocapt/cameradialog.cpp
@@ -207,14 +207,16 @@ void cameraDialog::getCameraInfo(QStringList devList)
       if(fd < 0)
         {
           QString msg=QString("Unable to open file %1\n%2").arg(camDev).arg(strerror(errno));
-          QMessageBox::warning(this,"v4l2ucp: Unable to open file", msg, "OK");
+          (void)QMessageBox::warning(this,"v4l2ucp: Unable to open file", msg,
+                                     QMessageBox::Ok, QMessageBox::Ok);
           continue;
         }
 
       if(v4l2_ioctl(fd, VIDIOC_QUERYCAP, &cap) == -1)
         {
           QString msg=QString("%1 is not a V4L2 device").arg(camDev);
-          QMessageBox::warning(this, "Camera selection error", msg, "OK");
+          (void)QMessageBox::warning(this, "Camera selection error", msg,
+                                     QMessageBox::Ok, QMessageBox::Ok);
           ok=false;
         }
       formats=getFormatList(fd);
@@ -230,10 +232,10 @@ void cameraDialog::getCameraInfo(QStringList devList)
 QString cameraDialog::pixelFormatStr(int pixelFormat)
 {
   QString t;
-  t=pixelFormat&0xFF;
-  t+=(pixelFormat>>8)&0xFF;
-  t+=(pixelFormat>>16)&0xFF;
-  t+=(pixelFormat>>24)&0xFF;
+  t= QChar((uchar)(pixelFormat&0xFF));
+  t+=QChar((uchar)((pixelFormat>>8)&0xFF));
+  t+=QChar((uchar)((pixelFormat>>16)&0xFF));
+  t+=QChar((uchar)((pixelFormat>>24)&0xFF));
   return t;
 }
 

--- a/src/videocapt/imagesettings.cpp
+++ b/src/videocapt/imagesettings.cpp
@@ -103,14 +103,16 @@ bool imageSettings::loadCapabilities()
   if(fd < 0)
     {
       QString msg=QString("Unable to open file %1\n%2").arg(camDev.constData()).arg(strerror(errno));
-      QMessageBox::warning(NULL, "v4l2ucp: Unable to open file", msg, "OK");
+      (void)QMessageBox::warning(NULL, "v4l2ucp: Unable to open file", msg,
+                                 QMessageBox::Ok, QMessageBox::Ok);
       return false;
     }
 
   if(v4l2_ioctl(fd, VIDIOC_QUERYCAP, &cap) == -1) {
       QString msg;
       msg=QString("%1 is not a V4L2 device").arg(camDev.constData());
-      QMessageBox::warning(NULL, "v4l2ucp: Not a V4L2 device", msg, "OK");
+      (void)QMessageBox::warning(NULL, "v4l2ucp: Not a V4L2 device", msg,
+                                 QMessageBox::Ok, QMessageBox::Ok);
       return false;
     }
   ui->driverLabel->setText((const char *)cap.driver);
@@ -243,7 +245,9 @@ void imageSettings::addNewTab(QString tabName)
   gridLayout = new QGridLayout();
   grid->setLayout(gridLayout);
   gridLayout->setSpacing(0);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   gridLayout->setMargin(1);
+#endif
   gridLayout->setContentsMargins(0, 0, 0, 0);
 }
 

--- a/src/videocapt/v4l2control.cpp
+++ b/src/videocapt/v4l2control.cpp
@@ -66,7 +66,8 @@ void V4L2Control::updateHardware()
     {
       QString msg;
       msg=QString("Unable to set %1\n%2").arg(name).arg(strerror(errno));
-      QMessageBox::warning(this, "Unable to set control", msg, "OK");
+      (void)QMessageBox::warning(this, "Unable to set control", msg,
+                                 QMessageBox::Ok, QMessageBox::Ok);
     }
   updateStatus();
 }
@@ -79,7 +80,8 @@ void V4L2Control::updateStatus()
     {
       QString msg;
       msg=QString("Unable to get %1\n%2").arg(name).arg(strerror(errno));
-      QMessageBox::warning(this, "Unable to get control", msg, "OK");
+      (void)QMessageBox::warning(this, "Unable to get control", msg,
+                                 QMessageBox::Ok, QMessageBox::Ok);
     }
   else
     {
@@ -92,7 +94,8 @@ void V4L2Control::updateStatus()
     {
       QString msg;
       msg=QString("Unable to get %1\n%2").arg(name).arg(strerror(errno));
-      QMessageBox::warning(this, "Unable to get control status", msg, "OK");
+      (void)QMessageBox::warning(this, "Unable to get control status", msg,
+                                 QMessageBox::Ok, QMessageBox::Ok);
     }
   else
     {
@@ -290,7 +293,8 @@ void V4L2ButtonControl::updateStatus()
   if(v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == -1) {
       QString msg;
       msg=QString("Unable to get the status of %1\n%2").arg(name).arg(strerror(errno));
-      QMessageBox::warning(this, "Unable to get control status", msg, "OK");
+      (void)QMessageBox::warning(this, "Unable to get control status", msg,
+                                 QMessageBox::Ok, QMessageBox::Ok);
     } else {
       setEnabled((ctrl.flags &( V4L2_CTRL_FLAG_DISABLED | V4L2_CTRL_FLAG_GRABBED)) == 0);
     }


### PR DESCRIPTION
The video4linux part still had some incompatibilites qith Qt6.

This fixes:

- all instances of QMessageBox to the not deprecated version
- QChar must be explicitly constructed from a uchar
- gridLayout->setMargin(1) is no longer available