### PR TITLE
Solve issue with non const rig_caps on hamlib

### DIFF
--- a/src/qsstv.pro
+++ b/src/qsstv.pro
@@ -511,7 +511,7 @@ contains(QMAKE_HOST.arch, arm.*):{
   else {
        message(Compiling for x86)
        CONFIG(debug ,debug|release){
-       dox.commands = cd $$PWD/documentation/manual ;doxygen  manual.doxy; cd $$PWD ;doxygen  $$PWD/documentation/api/api.doxy;
+       dox.commands = cd $$PWD/documentation/manual ;doxygen  manual.y; cd $$PWD ;doxygen  $$PWD/documentation/api/api.doxy;
        dox.depends= FORCE
        PRE_TARGETDEPS       +=    dox
        message(dox will be generated)

--- a/src/rig/rigcontrol.cpp
+++ b/src/rig/rigcontrol.cpp
@@ -40,14 +40,29 @@
 #define HAMLIB_FILPATHLEN FILPATHLEN
 #endif
 
+#ifdef RIGCAPS_NOT_CONST
+  /* Since this commit:
+   *   https://github.com/Hamlib/Hamlib/commit/ed941939359da9f8734dbdf4a21a9b01622a1a6e
+   * a 'struct rig_caps' is no longer constant (as passed to 'rig_list_foreach()' etc.).
+   */
+  QList<rig_caps *> capsList;
+#else
+  QList<const rig_caps *> capsList;
+#endif
 
-QList<const rig_caps *> capsList;
 bool radiolistLoaded=false;
 
 
 
-
+#ifdef RIGCAPS_NOT_CONST
+/* Since this commit:
+   *   https://github.com/Hamlib/Hamlib/commit/ed941939359da9f8734dbdf4a21a9b01622a1a6e
+   * a 'struct rig_caps' is no longer constant (as passed to 'rig_list_foreach()' etc.).
+   */
+int collect(rig_caps *caps,rig_ptr_t)
+#else
 int collect(const rig_caps *caps,rig_ptr_t)
+#endif
 {
   capsList.append(caps);
   return 1;


### PR DESCRIPTION
Since this commit:
https://github.com/Hamlib/Hamlib/commit/ed941939359da9f8734dbdf4a21a9b01622a1a6e
a 'struct rig_caps' is no longer constant (as passed to 'rig_list_foreach()' etc.).