### PR TITLE
Support FSKID with 10 characters

### DIFF
--- a/src/sstv/visfskid.cpp
+++ b/src/sstv/visfskid.cpp
@@ -191,7 +191,7 @@ bool fskIdDecoder::assemble(bool reset)
       checksum=checksum^symbol;
       fskIDStr.append(char(symbol+0x20));
       addToLog(QString("fskstr %1 %2").arg(fskIDStr).arg(QString::number(symbol,16)),LOGFSKID);
-      if(fskIDStr.length()>9)
+      if(fskIDStr.length()>10)
         {
           fskIDStr.clear();
           return true;


### PR DESCRIPTION
This month I am operating a special event call sign, PB31EASTER, unfortunately it seems the maximum length for receiving FSKID is 9.

I am not sure if this is some sort of standard, QSSTV can send my FSKID, but not receive it.

It also seems the local repeater does not like an FSKID of 9.

Anyway with this patch it does work.