### PR TITLE
Fix typos found with codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want to be able to debug the program, the simplest way is to install QtCr
 
 `sudo apt-get install doxygen libqwt-qt5-dev`
 
-You can also run qmake with the following atributes:
+You can also run qmake with the following attributes:
 
 `qmake CONFIG+=debug`
 

--- a/documentation/manual/manual.doxy
+++ b/documentation/manual/manual.doxy
@@ -1625,7 +1625,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/documentation/manual/manual.txt
+++ b/documentation/manual/manual.txt
@@ -68,7 +68,7 @@ QSSTV 9.5.x Support for Qt 5.15.X
 
 QSSTV 9.4.x has the following new features compared to QSSTV 9.3.x
 - improved template editor
-     (PLease run all your templates through the new editor to allign items correctly and save them again as a template with the same name)
+     (Please run all your templates through the new editor to align items correctly and save them again as a template with the same name)
 
 QSSTV 9.3.x has the following new features compared to QSSTV 9.2.x
 - Repeater functions are implemented now (both SSTV and DRM).
@@ -102,7 +102,7 @@ QSSTV 9.2.x has the following new features compared to QSSTV 8.2.x
     - processing and initialization of DRM frames taking too long
     - Fftw plan on arm processors is very slow.
     - made some changes to make it "runnable" on Raspberry Pi.<br>
-    - (tested on RPI 4 (4G) , Rasberry OS / Buster)
+    - (tested on RPI 4 (4G) , Raspberry OS / Buster)
 
 \li 20210731 QSSTV 9.5.7
     - switching to DRM was taking more dan 45 seconds on slow cpu's.
@@ -154,14 +154,14 @@ QSSTV 9.2.x has the following new features compared to QSSTV 8.2.x
     - redesign of the template editor
     - fixed template image corruption when image Fit mode was selected.
     - use of transparent images fixed (imageBackgroundColor (see Config GUI) is used to process transparency)
-    - removed c++11 Config option in qsstv.pro. Eliminated dependencies on c++11 to commpile with older compilers.
+    - removed c++11 Config option in qsstv.pro. Eliminated dependencies on c++11 to compile with older compilers.
 
 
 \li 20190418 QSSTV 9.3.3
   - fixed api documentation generation
 
 \li 20190418 QSSTV 9.3.2
- - complete rewrite of the FTP interfaces. They now run in a seperate thread
+ - complete rewrite of the FTP interfaces. They now run in a separate thread
  - removed Hybrid notify config. All hybrid configurations are in one tab: Hybrid
  - size of recorded wav files was internally set to 0, fixed.
  - tx audio to wav file was output in mono with half the samples -> fixed
@@ -203,8 +203,8 @@ QSSTV 9.2.x has the following new features compared to QSSTV 8.2.x
 
 \li 20161022 QSSTV 9.2.4
 - some minor bugfixing
-- eliminated online status setting in Config Notication tab (doubled with setting in Operator settings)
-- bug fix: incremental counter on filename wih hybrid mode
+- eliminated online status setting in Config Notification tab (doubled with setting in Operator settings)
+- bug fix: incremental counter on filename with hybrid mode
 - added filename to statusbar when sending DRM image
 
 \li 20161021 QSSTV 9.2.3
@@ -212,7 +212,7 @@ QSSTV 9.2.x has the following new features compared to QSSTV 8.2.x
 - faster compression of tx images
 - bug-fix: hybrid mode saved images with wrong file extension. Receivers tried downloading wrong file.
 - Added all the patches (more then 20) from Mike, VK6M: rx/tx notifications and a large number of patches for image handling
-- Added new features (such a save waterfall image) implmented by Mike, VK6M
+- Added new features (such a save waterfall image) implemented by Mike, VK6M
 - Todo: update the documentation !
 
 \li 20160929 QSSTV 9.2.2
@@ -272,7 +272,7 @@ bottom taskbars are masking part of the QSSTV window.
 - fixed hang on exit
 
 \li 20150928 QSSTV 9.0.6
-- performace optimization (especially for Raspberry Pi 2)
+- performance optimization (especially for Raspberry Pi 2)
 
 \li 20150926 QSSTV 9.0.4
 - added option for slow cpu (see Options ->GUI) This makes it possible to run QSSTV running on a Raspberry Pi 2.
@@ -321,7 +321,7 @@ On older distributions:
 On newer distributions
 <pre>sudo apt-get install libhamlib++-dev</pre>
 
-If you don't find libopenjp2-7 you can download it with the follwing commands if you're running a Debian derived distribution:
+If you don't find libopenjp2-7 you can download it with the following commands if you're running a Debian derived distribution:
 
 <pre>wget http://ftp.de.debian.org/debian/pool/main/o/openjpeg2/libopenjp2-7_2.1.0-2_i386.deb</pre>
 <pre>wget http://ftp.de.debian.org/debian/pool/main/o/openjpeg2/libopenjp2-7-dev_2.1.0-2_i386.deb</pre>
@@ -367,7 +367,7 @@ Note: you will need to install doxygen and libqwt
 <pre>
 sudo apt-get install doxygen libqwt-qt5-dev
 </pre>
-You can also run qmake with the following atributes:
+You can also run qmake with the following attributes:
 <pre>qmake CONFIG+=debug</pre>
 and use an external debugger (such as gdb)
 
@@ -382,7 +382,7 @@ The program is build around 3 windows
 <br>
 The program will remember the last position and the size of each window on restart.
 
-Start the program and follow the configuation and calibration instructions below.
+Start the program and follow the configuration and calibration instructions below.
 
 \page config Configuration
 
@@ -428,7 +428,7 @@ The following tabs are available
 - Image Background Colour: Default image background
 Push the push button to select the colour selector.
 - Gallery: Rows and columns: set-up the number of rows and columns to be used in the Gallery tab. If you're running on a slow CPU (like on a Raspberry Pi) select row=1 and columns=1.
-- Slow CPU: Select this option if you're running on a slow CPU (e.g. Rapsberry Pi)
+- Slow CPU: Select this option if you're running on a slow CPU (e.g. Raspberry Pi)
 - Low Resolution: Select this option if your display is for example 800x480. This options sets the maximum vertical resolution of QSSTV to less than 480 lines. It therefore removes some features
 from the receive window (Rx Notification Window in DRM) and the transmit window (Image replay Preview and TX Notifications in DRM mode).
 You can toggle to and from full screen by using the CTRL_F key combination.
@@ -459,7 +459,7 @@ See also \ref volume
    - Playback: playback a wav-file (use 48000 samples per second recording in mono or stereo)
    - Playback and record: playback the sound and record at the same time.
  - Swap left and right channel
-    - If selected, audio will be sent on the right audio channel instead of the left channel (e.g Kenwood tranceivers using USB sound interfaces)
+    - If selected, audio will be sent on the right audio channel instead of the left channel (e.g Kenwood transceivers using USB sound interfaces)
  - PTT tone on other audio channel
     - A tone will be sent on the right channel to enable PTT. If the above "Swap left and right channel" is selected, it will be sent on the left channel.
 <br><br>
@@ -488,7 +488,7 @@ You cannot select both +RTS and -RTS or +DTR and -DTR at the same time.
 let Hamlib use the RTS or DTR on the serial port specified by "PTT Serial Port".
 - There are 2 CAT ports:
     -CAT (voice port): the normal setting
-    -CAT (data port): to be used with some kenwood tranceivers(e.g. kenwood TS-480) to force data port instead of audio port (source: David  VK3DCU)
+    -CAT (data port): to be used with some kenwood transceivers(e.g. kenwood TS-480) to force data port instead of audio port (source: David  VK3DCU)
 Example: IC-706MKIIG via a cat interface such as interfaceOne.
 \anchor flrigconfig
 - Enable XMLRPC
@@ -597,14 +597,14 @@ You will either see a pop-up with "Connection OK" or an error message showing th
 - Password: will be encrypted
 - Directory: default empty
 
-Login name, password,hostname and directories will be encrypted before being sent on the air.
+Login name, password, hostname and directories will be encrypted before being sent on the air.
 
 The directories on the FTP server must be created at root level.
 - HybridFiles1 -- where the hybrid files are uploaded
 - RxOkNotifications1 -- where the notification are sent when receiving an DRM image
 - OnlineCallsigns1 -- where the call sign and info text is sent
 
-If a directory is specified (e.g test) then the following directories must be cretaed:
+If a directory is specified (e.g test) then the following directories must be created:
 - test/HybridFiles1
 - test/RxOkNotifications1
 - test/OnlineCallsigns1
@@ -681,7 +681,7 @@ remote           local      st poll reach  delay   offset    disp
 </pre>
 
 
-Newer sytems default install timesyncd instead of ntpd.
+Newer systems default install timesyncd instead of ntpd.
 timesyncd connects to the same time servers and works in roughly the same way,
 but is more lightweight and more integrated with systemd.
 The status of timesyncd can be checked by running timedatectl with no arguments.
@@ -906,7 +906,7 @@ The three markers above the waterfall indicate  the position of the pilot freque
 <br>
 Who is On?
 Information about other station on the hybrid server. There are some
-- The stations must enable : Allow other users to see youtr online status ... see  \ref operator configuration
+- The stations must enable : Allow other users to see your online status ... see  \ref operator configuration
 
 see \ref RXSSTV
 
@@ -970,7 +970,7 @@ QAM 64 : most demanding, used on VHF/UHF in really good conditions<br>
 QAM 16 : used on VHF/UHF in fairly good conditions sometime also on HF<br>
 QAM  4 : least demanding, used on HF <br>
 
-Bandwith:
+Bandwidth:
 - 2.5 kHz: VHF/UHF
 - 2.2 kHz; HF
 
@@ -1028,7 +1028,7 @@ The Gallery contains six tabs. The directories where the different images are st
 - TX Stock: Contains your selection of "Stock" images you want to use for transmission.
 - Templates: template images to be used as overlay on tx images
 <br> <br>
-Some examles
+Some examples
 \image html Gallery_txdrm.png
 <br>
 \image html Gallery_templates.png
@@ -1286,7 +1286,7 @@ It will first receive an image and after decoding it will retransmit the process
 The repeater acts like a parrot, it is not just retransmitting the audio.
 
 
-When the repeater is inactief for a time (idle time) specified in the repeater configuration, 1 of 4 images will be transmitted.
+When the repeater is inactive for a time (idle time) specified in the repeater configuration, 1 of 4 images will be transmitted.
 The overlay can be specified in the configuration.
 
 The retransmitted images are send in the mode selected in the Transmit window.
@@ -1296,7 +1296,7 @@ The repeater does not allow for cross-mode (i.e SSTV repeated in DRM or vice ver
 
 Images will only be repeated if:
 - For DRM: the image was received without errors or after correction.
-- For SSTV: the image was received and the Complete precentage has been met.
+- For SSTV: the image was received and the Complete percentage has been met.
 
 In DRM the repeater will never use Hybrid mode to repeat the image.
 
@@ -1318,7 +1318,7 @@ Easypal was used extensively to test my program. <br>
 
 Erik is now silent key as of 14th march 2015.     We will miss him.
 <br>
-I hope there will be other OM's that take up the maintenance,enhancements  and development of EasyPal so that people running Windows will continue to enjoy his software.
+I hope there will be other OM's that take up the maintenance, enhancements and development of EasyPal so that people running Windows will continue to enjoy his software.
 
 \page externalprog External Programs
 

--- a/src/dispatch/dispatchevents.h
+++ b/src/dispatch/dispatchevents.h
@@ -105,7 +105,7 @@ public:
 
 
 /**
-  this event is send with teh sync quality info and the signal volume
+  this event is send with the sync quality info and the signal volume
 */
 class displaySyncEvent : public baseEvent
 {

--- a/src/drmtx/common/util/Buffer.h
+++ b/src/drmtx/common/util/Buffer.h
@@ -220,7 +220,7 @@ template<class TData> CVectorEx<TData>* CCyclicBuffer<TData>::Get(const int iReq
 #ifdef _DEBUG_
 	if (iAvailSpace < iRequestedSize)
 	{
-		DebugError("CyclicBuffer Get()", "Availabe space",
+		DebugError("CyclicBuffer Get()", "Available space",
 			iAvailSpace, "Requested size", iAvailSpace);
 	}
 #endif

--- a/src/dsp/nco.h
+++ b/src/dsp/nco.h
@@ -48,7 +48,7 @@ class NCO  // numerical controlled oscillator
   ~NCO()
     {
     }
-	/** initialize the oscilator
+	/** initialize the oscillator
 
 			This function is automatically called from the constructor
 			\param[in] frequency the frequency the oscillator must be running at

--- a/src/editor/gradientdialog.h
+++ b/src/editor/gradientdialog.h
@@ -50,7 +50,7 @@ struct sgradientParam
 */
 class gradientForm;
 
-/** Widget to disply the various canvasItems */
+/** Widget to display the various canvasItems */
 class gradientDialog : public QDialog,private Ui::gradientForm
 {
 Q_OBJECT

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -85,7 +85,7 @@ mainWindow::mainWindow(QWidget *parent) : QMainWindow(parent),  ui(new Ui::MainW
   pttIcon->setFrameShape(QFrame::Panel);
   pttIcon->setFrameShadow(QFrame::Raised);
   pttIcon->setLineWidth(2);
-  rigControllerPtr=new rigControl(1); // must preceed configDialog construction
+  rigControllerPtr=new rigControl(1); // must precede configDialog construction
   configDialogPtr=new configDialog(this);
   configDialogPtr->readSettings();
 

--- a/src/rig/rigcontrol.cpp
+++ b/src/rig/rigcontrol.cpp
@@ -123,7 +123,7 @@ bool rigControl::init()
   // int verbose=0;
   // rig_set_debug(verbose<2 ? RIG_DEBUG_NONE: (rig_debug_level_e)verbose);
   // rig_debug(RIG_DEBUG_VERBOSE, "rigctl, %s\n", hamlib_version);
-  // test if we can contact the tranceiver
+  // test if we can contact the transceiver
 
   canSetFreq=(my_rig->caps->set_freq != NULL);
   canGetFreq=(my_rig->caps->get_freq != NULL);

--- a/src/sound/calibration.cpp
+++ b/src/sound/calibration.cpp
@@ -65,11 +65,11 @@ calibration::~calibration()
 /**
  * @brief start calibration
  *
- * Call this function to start the calibration proces. The use the results, check the return status and get the value of the clocks by calling getRXClock() and getTXClock().
+ * Call this function to start the calibration process. The use the results, check the return status and get the value of the clocks by calling getRXClock() and getTXClock().
  *
  * \sa getRXClock() \sa getTXClock()
  *
- * @return bool true if calibration is successful. Return false if an error occured or the dialog was canceled
+ * @return bool true if calibration is successful. Return false if an error occurred or the dialog was canceled
  */
 int calibration::exec()
 {
@@ -115,7 +115,7 @@ void calibration::init()
  * @brief slot for finish
  *
  * This slot is called when the dialog is closed by pressing CANCEL or OK. It will abort the loop executed in start and set the bool canceled to false or true
- * depending on the CANCEL or OK button being presssed.
+ * depending on the CANCEL or OK button being pressed.
  **/
 
 void calibration::hasFinished(int result)
@@ -132,7 +132,7 @@ void calibration::hasFinished(int result)
  *
  * Start is called by exec and performs the clock calibration using NTP (Network Time Protocol).
  * It starts counting when the first 100 blocks are read or when the first 100 blocks are written in order to start with a stable condition.
- * @return bool returns true if calibration is successful or false when either the CANCEL button was pressed or a read NTP time erro has occured.
+ * @return bool returns true if calibration is successful or false when either the CANCEL button was pressed or a read NTP time error has occurred.
  *
  **/
 

--- a/src/sound/soundalsa.cpp
+++ b/src/sound/soundalsa.cpp
@@ -289,7 +289,7 @@ bool soundAlsa::setupSoundParams(bool isCapture)
 
       snd_pcm_hw_params_get_channels_min(hwparams,&minChannelsPlayback);
       snd_pcm_hw_params_get_channels_max(hwparams,&maxChannelsPlayback);
-      err = snd_pcm_hw_params_set_channels ( handle, hwparams, 2); //allways stereo output
+      err = snd_pcm_hw_params_set_channels ( handle, hwparams, 2); //always stereo output
       if(!alsaErrorHandler(err,"Channels count not correct; " ))
         {
           return false;

--- a/src/sound/soundbase.cpp
+++ b/src/sound/soundbase.cpp
@@ -179,7 +179,7 @@ int soundBase::capture()
 
       if((storedFrames<=(ulong)recordingSize*1048576L) && (soundRoutingInput==SNDINCARDTOFILE))
         {
-          addToLog(QString("writen %1 tofile").arg(count),LOGSOUND);
+          addToLog(QString("written %1 tofile").arg(count),LOGSOUND);
           waveOut.write((quint16*)tempRXBuffer,count,false);
           storedFrames+=count;
         }

--- a/src/sound/wavio.cpp
+++ b/src/sound/wavio.cpp
@@ -145,7 +145,7 @@ bool  wavIO::openFileForRead(QString fname,bool ask)
 
   \param dPtr pointer to buffer for SOUNDFRAME type samples.
   \param numSamples  number of samples to read
-  \return returns the number of samples read. -1 is returned if there is an error, 0 is returned on end of the file else the numeber of samples read.
+  \return returns the number of samples read. -1 is returned if there is an error, 0 is returned on end of the file else the number of samples read.
 
 The file will be closed on reaching the end of file;
 
@@ -163,7 +163,7 @@ int  wavIO::read(short int *dPtr ,uint numSamples)
       return -1;
     }
 
-  llen=numSamples*sizeof(quint16)*numberOfChannels; // lenght in bytes
+  llen=numSamples*sizeof(quint16)*numberOfChannels; // length in bytes
   if(waveHeader.numChannels==1)
     {
       result=inopf.read((char*)dPtr,llen); //we do not need conversion

--- a/src/sstv/modes/modebase.cpp
+++ b/src/sstv/modes/modebase.cpp
@@ -346,7 +346,7 @@ void modeBase::showLine()
   combineColors();
 }
 /**
-  \brief tranfer data to rxImage in RGB mode
+  \brief transfer data to rxImage in RGB mode
 
   Combine  R, G and B arrays (like in Martin mode) into the rxImage and advances the displayCounter
 */
@@ -368,7 +368,7 @@ void modeBase::combineColors()
 
 
 /**
-  \brief tranfer data to rxImage in grayscale
+  \brief transfer data to rxImage in grayscale
 
   Black and White image transfer. greenArray contains the luminance info.
 */
@@ -386,7 +386,7 @@ void modeBase::grayConversion()
 }
 
 /**
-  \brief tranfer data to rxImage in YUV mode
+  \brief transfer data to rxImage in YUV mode
 
   Combine  Y, U  and V arrays (like in PD modes) into the rxImage and advances the displayCounter
 */

--- a/src/sstv/sstvparam.h
+++ b/src/sstv/sstvparam.h
@@ -103,7 +103,7 @@ enum esstvMode
 
 /*
 
-// struc used in frequency detection 
+// struct used in frequency detection
 struct sTimeFreq
 {
   DSPFLOAT t;            // time in sec

--- a/src/sstv/syncprocessor.cpp
+++ b/src/sstv/syncprocessor.cpp
@@ -296,7 +296,7 @@ void syncProcessor::extractSync()
  *
  * The function evaluates the sync pulse width and sets the retrace flag
  * *
- * \retval false if no valid sync and no further processing is neeeded
+ * \retval false if no valid sync and no further processing is needed
  *         true if a new syncArray entry is added and further processing is necessary
  */
 

--- a/src/utils/dirdialog.cpp
+++ b/src/utils/dirdialog.cpp
@@ -111,7 +111,7 @@ QString dirDialog::openDirName(const QString &path)
     Saves a file to disk. A dialogbox is opened with \a startWith directory (or /dir/subdir/..../filename) preselected
     \param path directory to open (can include filename to preselect)
     \param filter    file types to select from (e.g. *.txt *.doc)
-    \param extension if extension is not empty or NULL, thenn this string will be appended to the filename. A dot will automatically be insterted (i.e specify "txt" not ".txt").
+    \param extension if extension is not empty or NULL, then this string will be appended to the filename. A dot will automatically be inserted (i.e specify "txt" not ".txt").
     \return if canceled or no selection then return an empty string else return string containing absolute filename.
 */
 

--- a/src/utils/ftpthread.cpp
+++ b/src/utils/ftpthread.cpp
@@ -371,7 +371,7 @@ void ftpThread::dumpState( int state )
       addToLog(QString("FTPss Closing name:=%1 :host=%2").arg(idName).arg(host),LOGFTPTHREAD);
       break;
     default:
-      addToLog(QString("FTPss uknown %1 name:=%2 host=%3").arg(qftpPtr->state()).arg(idName).arg(host),LOGFTPTHREAD);
+      addToLog(QString("FTPss unknown %1 name:=%2 host=%3").arg(qftpPtr->state()).arg(idName).arg(host),LOGFTPTHREAD);
       break;
     }
 }

--- a/src/utils/jp2io.cpp
+++ b/src/utils/jp2io.cpp
@@ -330,7 +330,7 @@ QImage jp2IO::decode(QString fileName)
       G = jp2Image->comps[1].data[ idx( x, y ) ];
       B = jp2Image->comps[2].data[ idx( x, y ) ];
 
-      // fill the bit with read pallete
+      // fill the bit with read palette
       bits[i] = qRgb(R, G, B);
     }
   destroy_parameters(&parameters);

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -121,7 +121,7 @@ bool logFile::reopen()
   errorOut() << "opening logfile: " << finfaux.absoluteFilePath();
   if(!auxFile->open(QIODevice::WriteOnly))
     {
-      errorOut() << "auxillary file creation failed";
+      errorOut() << "auxiliary file creation failed";
       lf->close();
       return false;
     }
@@ -238,7 +238,7 @@ void logFile::addToAux(QString t)
 void logFile::addToAux(QString ){}
 #endif
 /*!
-  if enable=true logging wil be performed
+  if enable=true logging will be performed
   \return previous logging state (true if logging was enabled)
 */
 

--- a/src/utils/qftp.cpp
+++ b/src/utils/qftp.cpp
@@ -229,7 +229,7 @@ private:
 
 /**********************************************************************
  *
- * QFtpCommand implemenatation
+ * QFtpCommand implementation
  *
  *********************************************************************/
 class QFtpCommand
@@ -278,7 +278,7 @@ QFtpCommand::~QFtpCommand()
 
 /**********************************************************************
  *
- * QFtpDTP implemenatation
+ * QFtpDTP implementation
  *
  *********************************************************************/
 QFtpDTP::QFtpDTP(QFtpPI *p, QObject *parent) :
@@ -771,7 +771,7 @@ void QFtpDTP::clearData()
 
 /**********************************************************************
  *
- * QFtpPI implemenatation
+ * QFtpPI implementation
  *
  *********************************************************************/
 QFtpPI::QFtpPI(QObject *parent) :
@@ -2103,7 +2103,7 @@ bool QFtp::hasPendingCommands() const
 */
 void QFtp::clearPendingCommands()
 {
-  // delete all entires except the first one
+  // delete all entries except the first one
   while (d->pending.count() > 1)
     delete d->pending.takeLast();
 }

--- a/src/utils/reedsolomoncoder.cpp
+++ b/src/utils/reedsolomoncoder.cpp
@@ -186,7 +186,7 @@ void reedSolomonCoder::distribute(_BYTE *src, _BYTE *dst, int rows, int cols, in
   rl = reverse ? cols : rows;
 
 
-  for(i=0;i<rc;i+=64) // ON4QZ changed from original- > using union gives problems with allignement
+  for(i=0;i<rc;i+=64) // ON4QZ changed from original- > using union gives problems with alignment
     {
       for(j=0;j<64 && i+j<rc;j++)
         {

--- a/src/utils/rs.cpp
+++ b/src/utils/rs.cpp
@@ -101,7 +101,7 @@ for(ci=(n)-1;ci >=0;ci--)\
    of the integer "alpha_to[i]" with a(0) being the LSB and a(m-1) the MSB. Thus for
    example the polynomial representation of @^5 would be given by the binary
    representation of the integer "alpha_to[5]".
-                   Similarily, index_of[] can be used as follows:
+                   Similarly, index_of[] can be used as follows:
         As above, let @ represent the primitive element of GF(2^m) that is
    the root of the primitive polynomial p(x). In order to find the power
    of @ (alpha) that has the polynomial representation
@@ -113,7 +113,7 @@ for(ci=(n)-1;ci >=0;ci--)\
    NOTE:
         The element alpha_to[2^m-1] = 0 always signifying that the
    representation of "@^infinity" = 0 is (0,0,0,...,0).
-        Similarily, the element index_of[0] = A0 always signifying
+        Similarly, the element index_of[0] = A0 always signifying
    that the power of alpha which has the polynomial representation
    (0,0,...,0) is "infinity".
  

--- a/src/videocapt/videocapture.cpp
+++ b/src/videocapt/videocapture.cpp
@@ -19,7 +19,7 @@
 *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
 *                                                                         *
 *                                                                         *
-*   This software contains parts of the following softwares               *
+*   This software contains parts of the following software                *
 *      videoCapture.cpp -- Kapture                                        *
 *                                                                         *
 *      Copyright (C) 2006-2009                                            *
@@ -383,7 +383,7 @@ bool videoCapture::stopStreaming()
   if(captureStop())
     {
       streaming = false;
-      addToLog(" * Succesful Stopped",LOGCAM);
+      addToLog(" * Successfully Stopped",LOGCAM);
     }
   return true;
 }

--- a/src/widgets/imageviewer.cpp
+++ b/src/widgets/imageviewer.cpp
@@ -861,7 +861,7 @@ bool imageViewer::copyToBuffer(QByteArray *ba)
 
 uint  imageViewer:: setSize(int tcompressSize, bool usesCompression)
 {
-  compressSize=tcompressSize; //allways set it
+  compressSize=tcompressSize; //always set it
   if(!usesCompression)
     {
       applyTemplate();

--- a/src/xmlrpc/maiaXmlRpcServerConnection.cpp
+++ b/src/xmlrpc/maiaXmlRpcServerConnection.cpp
@@ -272,7 +272,7 @@ QByteArray getReturnType(const QMetaObject *obj,const QByteArray &method, const 
 }
 
 /*
-  simple Qt4 class emulater
+  simple Qt4 class emulator
 */
 
 #if QT_VERSION >= 0x050000


### PR DESCRIPTION
This PR fixes small errors in the documentation, in some messages and in some comments.

Codespell https://github.com/codespell-project/codespell shows other possible errors and some false positives in *.cpp files that I'm not fixing at this time.