### PR TITLE
Fix desktop categories

### DIFF
--- a/qsstv.desktop
+++ b/qsstv.desktop
@@ -9,5 +9,5 @@ NoDisplay=false
 StartupNotify=true
 Terminal=false
 Type=Application
-Categories=Education;
+Categories=Network;HamRadio;
 X-AppImage-Version=1


### PR DESCRIPTION
These categories are also used for other ham radio related apps and are in my opinion much more suitable for QSSTV than the current "Education" category.

Already [fixed downstream](https://salsa.debian.org/debian-hamradio-team/qsstv/-/blob/master/debian/patches/Desktop-entry.patch?ref_type=heads#L12) in Debian/Ubuntu.