### PR TITLE
Drop annoying debug output

### DIFF
--- a/src/rig/rigcontrol.cpp
+++ b/src/rig/rigcontrol.cpp
@@ -152,9 +152,9 @@ bool rigControl::getFrequency(double &frequency)
   retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &frequency);
   for(int i=0;i<RIGCMDTRIES;i++)
     {
-      qDebug() << "getFreq";
+//      qDebug() << "getFreq";
       retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &frequency);
-      qDebug() << "got Freq";
+//      qDebug() << "got Freq";
       if (retcode==RIG_OK)
         {
           return true;


### PR DESCRIPTION
Each polling of hamlib frequency is surrounded by a 'getFreq' and a 'got Freq' output on command line.
If needed it should be done by the general logging facility.