### PR TITLE
Fix Serial PTT lines not being released

### DIFF
--- a/src/rig/rigcontrol.cpp
+++ b/src/rig/rigcontrol.cpp
@@ -415,9 +415,9 @@ void rigControl::activatePTT(bool b)
             {
               ioctl(serialP,TIOCMGET,&modemlines);
               if(catParams.activeDTR) modemlines |= TIOCM_DTR;
-              if(catParams.activeRTS)modemlines |= TIOCM_RTS;
+              if(catParams.activeRTS) modemlines |= TIOCM_RTS;
               if(catParams.nactiveDTR) modemlines &= ~TIOCM_DTR;
-              if(catParams.nactiveRTS)modemlines &= ~TIOCM_RTS;
+              if(catParams.nactiveRTS) modemlines &= ~TIOCM_RTS;
               ioctl(serialP,TIOCMSET,&modemlines);
               //ioctl(serial,TIOCMBIS,&t);
             }
@@ -426,8 +426,8 @@ void rigControl::activatePTT(bool b)
               ioctl(serialP,TIOCMGET,&modemlines);
               if(catParams.activeDTR) modemlines &= ~TIOCM_DTR;
               if(catParams.activeRTS) modemlines &= ~TIOCM_RTS;
-              if(catParams.nactiveDTR) modemlines |= ~TIOCM_DTR;
-              if(catParams.nactiveRTS)modemlines |= ~TIOCM_RTS;
+              if(catParams.nactiveDTR) modemlines |= TIOCM_DTR;
+              if(catParams.nactiveRTS) modemlines |= TIOCM_RTS;
               ioctl(serialP,TIOCMSET,&modemlines);
             }
         }


### PR DESCRIPTION
Fix a small Boolean logic bug that prevents the negative DTR and negative RTS lines from being reset properly when PTT is released.

Fixes issue #70 